### PR TITLE
Add company_information stream to README; fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ This tap:
 - Transformations: camelCase to snake_case
 - Parent: campaigns
 
+[company_information](https://developer.impact.com/default#operations-Company_Information-GetCompanyInfo)
+- Endpoint: https://api.impact.com/{api_catalog}/{account_sid}/CompanyInformation
+- Primary key fields: company_name
+- Foreign key fields: None
+- Replication strategy: FULL_TABLE
+- Transformations: camelCase to snake_case
+
 [contacts](https://developer.impact.com/default#operations-Contacts-GetContacts)
 - Endpoint: https://api.impact.com/{api_catalog}/{account_sid}/Campaigns/{campaign_id}/Contacts
 - Primary key fields: id

--- a/tap_impact/schemas/clicks.json
+++ b/tap_impact/schemas/clicks.json
@@ -42,7 +42,7 @@
     "customer_city": {
       "type": ["null", "string"]
     },
-    "customer_country\"": {
+    "customer_country": {
       "type": ["null", "string"]
     },
     "customer_region": {


### PR DESCRIPTION
# Description of change
This PR:

- Adds the `company_information` schema to the README
- Fixes a typo in the `clicks` schema

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
