### PR TITLE
Bumping to 1.0.0 for GA release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.0
+  * Added circle, pylint, and bumped to 1.0.0 for GA release
+
 ## 0.0.4
   * Fix issue for `conversion_paths`. Increase JSON schema decimal digits to `multipleOf` = `1e-8`.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-impact',
-      version='0.0.4',
+      version='1.0.0',
       description='Singer.io tap for extracting data from the Impact Advertiser, Partner, Agency APIs',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Bumping to 1.0.0 for GA release - https://stitchdata.atlassian.net/browse/SRCE-3698

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
