### PR TITLE
Change customer_id from integer to string in schemas

### DIFF
--- a/tap_impact/schemas/action_updates.json
+++ b/tap_impact/schemas/action_updates.json
@@ -35,7 +35,7 @@
       "type": ["null", "string"]
     },
     "customer_id": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     },
     "customer_status": {
       "type": ["null", "string"]

--- a/tap_impact/schemas/conversion_paths.json
+++ b/tap_impact/schemas/conversion_paths.json
@@ -36,7 +36,7 @@
       "type": ["null", "integer"]
     },
     "customer_id": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     },
     "uri": {
       "type": ["null", "string"]


### PR DESCRIPTION
# Description of change

Change the `customer_id` field in the `conversion_paths` and `action_updates` schemas to be a string, which falls in line with the current `actions` schema.


# Manual QA steps
 - 
 
# Risks
 -  Existing integrations may fail if the target table is typed for an integer. However this may not be the case if the target database is able to automatically typecast the string to an integer.
 
# Rollback steps
 - revert this branch
