### PR TITLE
stitch validate json relative path instead of python 3.5 virtual env hardcoded path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             python3 -m venv /usr/local/share/virtualenvs/tap-impact
             source /usr/local/share/virtualenvs/tap-impact/bin/activate
-            pip install -U 'pip<19.2'
+            pip install -U pip setuptools
             pip install .[dev]
       - run:
           name: 'pylint'
@@ -21,7 +21,7 @@ jobs:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-impact/lib/python3.5/site-packages/tap_impact/schemas/*.json
+            stitch-validate-json tap_impact/schemas/*.json
       # - run:
       #     name: 'Unit Tests'
       #     command: |

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(name='tap-impact',
       ],
       extras_require={
           'dev': [
-              'ipdb==0.11',
-              'pylint==2.5.3'
+              'ipdb==0.13.7',
+              'pylint==2.7.2'
           ]
       },
       entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(name='tap-impact',
       ],
       extras_require={
           'dev': [
-              'ipdb==0.13.7',
-              'pylint==2.7.2'
+              'ipdb==0.11',
+              'pylint==2.5.3'
           ]
       },
       entry_points='''


### PR DESCRIPTION
# Description of change
stitch validate json relative path instead of python 3.5 virtual env hardcoded path

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
