### PR TITLE
Fix failing sync if model_id is set to null in config

### DIFF
--- a/tap_impact/sync.py
+++ b/tap_impact/sync.py
@@ -287,7 +287,7 @@ def sync_endpoint(client,
             if children:
                 for child_stream_name, child_endpoint_config in children.items():
                     if child_stream_name in selected_streams:
-                        model_id = config.get('model_id', '')
+                        model_id = config.get('model_id', '') or ''
                         process_child = True
                         # conversion_paths endpoint requires model_id tap config param
                         if child_stream_name == 'conversion_paths' and model_id == '':


### PR DESCRIPTION
# Description of change
Fixes https://github.com/singer-io/tap-impact/issues/12

# Manual QA steps
Ran tap locally in sync mode
 
# Risks
 - Can't think of any, it's a pretty simple change.
 
# Rollback steps
 - revert this branch
