### PR TITLE
Updated data type for customer_id

### DIFF
--- a/tap_impact/schemas/action_updates.json
+++ b/tap_impact/schemas/action_updates.json
@@ -35,7 +35,7 @@
       "type": ["null", "string"]
     },
     "customer_id": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     },
     "customer_status": {
       "type": ["null", "string"]


### PR DESCRIPTION

# Description of change
Updated customer_id data type to be string.
From https://integrations.impact.com/impact-brand/reference/the-action-update-object#customerid-string the customer_id should be a string.  We're seeing 

customer_id: <customer_id_string> does not match {'selected': True, 'inclusion': 'available', 'type': ['integer', 'null']}
During replication using Stitch's impact Integration.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
