### PR TITLE
TDL-21232 fix replace error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='tap-impact',
       ],
       extras_require={
           'dev': [
-              'ipdb==0.11',
+              'ipdb',
               'pylint==2.5.3'
           ]
       },

--- a/tap_impact/sync.py
+++ b/tap_impact/sync.py
@@ -290,7 +290,7 @@ def sync_endpoint(client,
                         model_id = config.get('model_id', '')
                         process_child = True
                         # conversion_paths endpoint requires model_id tap config param
-                        if child_stream_name == 'conversion_paths' and model_id == '':
+                        if child_stream_name == 'conversion_paths' and not model_id:
                             process_child = False
                         if process_child:
                             write_schema(catalog, child_stream_name)


### PR DESCRIPTION
# Description of change
Tap is throwing below error when user edits the connection page and doesn't configure the model_id field. Somehow the app is setting the `model_id` to `None` in config json when user edits the connection page.

```
2022-11-04 05:30:22,302Z    tap - CRITICAL replace() argument 2 must be str, not None
2022-11-04 05:30:22,302Z    tap - Traceback (most recent call last):
2022-11-04 05:30:22,302Z    tap -   File "/code/orchestrator/tap-env/bin/tap-impact", line 33, in <module>
2022-11-04 05:30:22,302Z    tap -     sys.exit(load_entry_point('tap-impact==1.0.0', 'console_scripts', 'tap-impact')())
2022-11-04 05:30:22,303Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/singer/utils.py", line 229, in wrapped
2022-11-04 05:30:22,303Z    tap -     return fnc(*args, **kwargs)
2022-11-04 05:30:22,303Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_impact/__init__.py", line 47, in main
2022-11-04 05:30:22,303Z    tap -     sync(client=client,
2022-11-04 05:30:22,303Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_impact/sync.py", line 406, in sync
2022-11-04 05:30:22,303Z    tap -     total_records = sync_endpoint(
2022-11-04 05:30:22,303Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_impact/sync.py", line 313, in sync_endpoint
2022-11-04 05:30:22,303Z    tap -     child_path = child_endpoint_config.get(
2022-11-04 05:30:22,303Z    tap - TypeError: replace() argument 2 must be str, not None
```

# Manual QA steps
 - 
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
