### PR TITLE
Set default value as empty string for model_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.0.2
-  * Sets empty string default for model_id if not configured [#23](https://github.com/singer-io/tap-impact/pull/23)
+  * Sets empty string as default value for model_id if not configured [#23](https://github.com/singer-io/tap-impact/pull/23)
 
 ## 1.0.1
   * Fix model_id parsing error when it is not configured [#22](https://github.com/singer-io/tap-impact/pull/22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.2
+  * Sets empty string default for model_id if not configured [#23](https://github.com/singer-io/tap-impact/pull/23)
+
 ## 1.0.1
   * Fix model_id parsing error when it is not configured [#22](https://github.com/singer-io/tap-impact/pull/22)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-impact',
-      version='1.0.1',
+      version='1.0.2',
       description='Singer.io tap for extracting data from the Impact Advertiser, Partner, Agency APIs',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_impact/sync.py
+++ b/tap_impact/sync.py
@@ -287,7 +287,7 @@ def sync_endpoint(client,
             if children:
                 for child_stream_name, child_endpoint_config in children.items():
                     if child_stream_name in selected_streams:
-                        model_id = config.get('model_id')
+                        model_id = config.get('model_id') or ''
                         process_child = True
                         # conversion_paths endpoint requires model_id tap config param
                         if child_stream_name == 'conversion_paths' and not model_id:


### PR DESCRIPTION
# Description of change
This PR sets default value of model_id as empty string when the field is not configured.

# Manual QA steps
 - Set the model_id to `None` in config and tested.
```
string = "hello/<model_id>/world"
config = {"singer": "io", 'model_id': None}
model_id = config.get('model_id') or ''
print(string.replace('<model_id>', model_id))
```
 - Set the model_id to `""` in config and tested.
```
string = "hello/<model_id>/world"
config = {"singer": "io", 'model_id': ''}
model_id = config.get('model_id') or ''
print(string.replace('<model_id>', model_id))
```

Above QA steps were ran using local python interpreter as it is difficult to write unit tests looking at the code structure
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
