### PR TITLE
fix (actions: enddate) add required enddate param

### DIFF
--- a/tap_impact/streams.py
+++ b/tap_impact/streams.py
@@ -38,7 +38,8 @@ STREAMS = {
                 'data_key': 'Actions',
                 'params': {
                     'CampaignId': '<parent_id>',
-                    'ActionDateStart': '<last_datetime>'
+                    'ActionDateStart': '<last_datetime>',
+                    'ActionDateEnd': '<current_datetime>',
                 },
                 'key_properties': ['id'],
                 'replication_method': 'INCREMENTAL',
@@ -50,7 +51,8 @@ STREAMS = {
                 'data_key': 'ActionInquiries',
                 'params': {
                     'CampaignId': '<parent_id>',
-                    'StartDate': '<last_datetime>'
+                    'StartDate': '<last_datetime>',
+                    'EndDate': '<current_datetime>'
                 },
                 'key_properties': ['id'],
                 'replication_method': 'INCREMENTAL',
@@ -62,7 +64,8 @@ STREAMS = {
                 'data_key': 'ActionUpdates',
                 'params': {
                     'CampaignId': '<parent_id>',
-                    'StartDate': '<last_datetime>'
+                    'StartDate': '<last_datetime>',
+                    'EndDate': '<current_datetime>'
                 },
                 'key_properties': ['id'],
                 'replication_method': 'INCREMENTAL',

--- a/tap_impact/sync.py
+++ b/tap_impact/sync.py
@@ -152,6 +152,7 @@ def sync_endpoint(client,
 
     end_dttm = utils.now()
     end_dt = end_dttm.date()
+    end_dt_str = end_dt.strftime('%Y-%m-%dT%H:%M:%SZ')
     start_dttm = end_dttm
     start_dt = end_dt
 
@@ -190,8 +191,12 @@ def sync_endpoint(client,
 
             if page == 1 and not params == {}:
                 param_string = '&'.join(['%s=%s' % (key, value) for (key, value) in params.items()])
-                querystring = param_string.replace('<parent_id>', str(parent_id)).replace(
-                    '<last_datetime>', strptime_to_utc(last_datetime).strftime('%Y-%m-%dT%H:%M:%SZ'))
+                querystring = (
+                    param_string
+                    .replace('<parent_id>', str(parent_id))
+                    .replace('<last_datetime>', strptime_to_utc(last_datetime).strftime('%Y-%m-%dT%H:%M:%SZ'))
+                    .replace('<current_datetime>', strptime_to_utc(end_dt_str).strftime('%Y-%m-%dT%H:%M:%SZ'))
+                )
             else:
                 querystring = None
             LOGGER.info('URL for Stream {}: {}{}'.format(


### PR DESCRIPTION
# Description of change

According [to api docs](https://integrations.impact.com/impact-brand/reference/list-all-actions), `EndDate` is required when providing a `StartDate`.  Including an `EndDate` should resolve the errors.

<img width="790" alt="357224401-1e63c8d2-0072-4aac-90c1-28e061683505" src="https://github.com/user-attachments/assets/ffac0e3a-afe7-48fd-9d39-5940c6244f07">

```json
ERROR ERROR 400: {\"Status\":\"ERROR\",\"Message\":\"Parameter 'ActionDateEnd' value is required.\"}
```



# Manual QA steps

 
# Risks
- none
 
# Rollback steps
 - revert this branch
