### PR TITLE
Change integer types to number in deals schema

### DIFF
--- a/tap_impact/schemas/deals.json
+++ b/tap_impact/schemas/deals.json
@@ -22,7 +22,7 @@
       "type": ["null", "string"]
     },
     "bogo_get_discount_percent": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "bogo_get_discount_type": {
       "type": ["null", "string"]
@@ -59,16 +59,16 @@
       "type": ["null", "string"]
     },
     "discount_maximum_percent": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_percent": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_percent_range_end": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_percent_range_start": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_type": {
       "type": ["null", "string"]


### PR DESCRIPTION
The Impact API returns decimal percentage values (e.g., 7.4%) but the schema incorrectly defined discount_percent and related fields as integer type, causing sync failures when encountering non-whole number percentages.

Changed the following fields from integer to number:
- bogo_get_discount_percent
- discount_maximum_percent
- discount_percent
- discount_percent_range_end
- discount_percent_range_start

This matches the schema definition already used in ads.json where these fields are correctly defined as number type.

Fixes sync error: "discount_percent: 7.4 does not match {'type': ['integer', 'null']}"

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
