### PR TITLE
Change type from 'integer' to 'number' in promo_codes schema

### DIFF
--- a/tap_impact/schemas/promo_codes.json
+++ b/tap_impact/schemas/promo_codes.json
@@ -28,7 +28,7 @@
       "type": ["null", "string"]
     },
     "bogo_get_discount_percent": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "bogo_get_discount_type": {
       "type": ["null", "string"]
@@ -163,16 +163,16 @@
       "type": ["null", "string"]
     },
     "discount_maximum_percent": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_percent": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_percent_range_end": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_percent_range_start": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_type": {
       "type": ["null", "string"]


### PR DESCRIPTION
Fix: Change discount percentage fields from integer to number in promo_codes schema

The Impact API returns decimal percentage values (e.g., 7.4%) but the schema
incorrectly defined discount_percent and related fields as integer type,
causing sync failures when encountering non-whole number percentages.

Changed the following fields from integer to number:
- bogo_get_discount_percent
- discount_maximum_percent
- discount_percent
- discount_percent_range_end
- discount_percent_range_start

This aligns with the fix applied to deals.json and matches the correct
schema definition in ads.json.

Part of fix for: "discount_percent: 7.4 does not match {'type': ['integer', 'null']}"