### PR TITLE
Change integer types to number in tracking_value_requests schema

### DIFF
--- a/tap_impact/schemas/tracking_value_requests.json
+++ b/tap_impact/schemas/tracking_value_requests.json
@@ -25,7 +25,7 @@
       "type": ["null", "string"]
     },
     "bogo_get_discount_percent": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "bogo_get_discount_type": {
       "type": ["null", "string"]
@@ -162,16 +162,16 @@
       "type": ["null", "string"]
     },
     "discount_maximum_percent": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_percent": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_percent_range_end": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_percent_range_start": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "discount_type": {
       "type": ["null", "string"]


### PR DESCRIPTION
Fix: Change discount percentage fields from integer to number in tracking_value_requests schema

The Impact API returns decimal percentage values (e.g., 7.4%) but the schema incorrectly defined discount_percent and related fields as integer type, causing sync failures when encountering non-whole number percentages.

Changed the following fields from integer to number:
- bogo_get_discount_percent
- discount_maximum_percent
- discount_percent
- discount_percent_range_end
- discount_percent_range_start

This completes the schema fix across all affected tables (deals, promo_codes, and tracking_value_requests) and aligns with the correct definition in ads.json.

Part of fix for: "discount_percent: 7.4 does not match {'type': ['integer', 'null']}"



